### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that connects to a Swagger specification and helps an AI to build all the required models to generate a MCP server for that service.
 
+<a href="https://glama.ai/mcp/servers/@Vizioz/Swagger-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Vizioz/Swagger-MCP/badge" alt="Swagger MCP server" />
+</a>
+
 ## Features
 
 - Downloads a Swagger specification and stores it locally for faster reference.


### PR DESCRIPTION
This PR adds a badge for the [Swagger MCP](https://glama.ai/mcp/servers/@Vizioz/Swagger-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Vizioz/Swagger-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Vizioz/Swagger-MCP/badge" alt="Swagger MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Glama MCP server badge to the README and fix a minor formatting issue.
> 
> - **Docs (`README.md`)**:
>   - Add Glama MCP server badge linking to the Swagger MCP listing.
>   - Fix formatting of the example use case line in the MCP prompts section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4dc7eca951ed514f41279366eca85cb9720a637. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->